### PR TITLE
add is_to_all support in sending mass message

### DIFF
--- a/lib/weixin_authorize/api/mass.rb
+++ b/lib/weixin_authorize/api/mass.rb
@@ -7,8 +7,8 @@ module WeixinAuthorize
 
       # media_info= {"media_id" media_id}
       # https://api.weixin.qq.com/cgi-bin/message/mass/sendall?access_token=ACCESS_TOKEN
-      def mass_with_group(group_id, media_info, msgtype="mpnews")
-        group_option = {"filter" => {"group_id" => group_id.to_s}}
+      def mass_with_group(group_id, media_info, msgtype="mpnews", is_to_all=false)
+        group_option = {"filter" => {"group_id" => group_id.to_s, "is_to_all" => is_to_all}}
         media = generate_media(msgtype, media_info, group_option)
 
         mass_url = "#{mass_base_url}/sendall"

--- a/spec/api/mass_spec.rb
+++ b/spec/api/mass_spec.rb
@@ -49,6 +49,11 @@ describe WeixinAuthorize::Api::Mass do
     expect(response.code).to eq(WeixinAuthorize::OK_CODE)
   end
 
+  it "#mass_with_groug send to all" do
+    response = $client.mass_with_group("1", "mass_group_text_to_all", "text", true)
+    expect(response.code).to eq(WeixinAuthorize::OK_CODE)
+  end
+
   it "#mass_with_openids with mpnews and can delete message" do
     response = $client.mass_with_openids([ENV["OPENID"]], mass_media_id)
     expect(response.code).to eq(WeixinAuthorize::OK_CODE)


### PR DESCRIPTION
群发接口，按分组群发， 增加发送到所有用户的参数。[相关文档](http://mp.weixin.qq.com/wiki/15/5380a4e6f02f2ffdc7981a8ed7a40753.html#.E6.A0.B9.E6.8D.AE.E5.88.86.E7.BB.84.E8.BF.9B.E8.A1.8C.E7.BE.A4.E5.8F.91.E3.80.90.E8.AE.A2.E9.98.85.E5.8F.B7.E4.B8.8E.E6.9C.8D.E5.8A.A1.E5.8F.B7.E8.AE.A4.E8.AF.81.E5.90.8E.E5.9D.87.E5.8F.AF.E7.94.A8.E3.80.91)