### PR TITLE
enhancement: create limit scene with parameter directly

### DIFF
--- a/lib/weixin_authorize/api/qrcode.rb
+++ b/lib/weixin_authorize/api/qrcode.rb
@@ -13,8 +13,7 @@ module WeixinAuthorize
 
       # 永久二维码
       # options: scene_id, scene_str
-      def create_qr_limit_scene(options)
-        scene_id = options[:scene_id]
+      def create_qr_limit_scene(scene_id)
         qrcode_infos = {action_name: "QR_LIMIT_SCENE"}
         qrcode_infos.merge!(action_info(scene_id))
         http_post(qrcode_base_url, qrcode_infos)
@@ -22,8 +21,7 @@ module WeixinAuthorize
 
       # 为永久的字符串参数值
       # options: scene_str
-      def create_qr_limit_str_scene(options)
-        scene_str = options[:scene_str]
+      def create_qr_limit_str_scene(scene_str)
         qrcode_infos = {action_name: "QR_LIMIT_STR_SCENE"}
         qrcode_infos.merge!(action_info(nil, scene_str))
         http_post(qrcode_base_url, qrcode_infos)


### PR DESCRIPTION
create_qr_limit_scene
create_qr_limit_str_scene
这俩方法，原来还需要个hash来传，方法体里面也不需要别的参数，我看微信文档还有源码，基本能判断也不需要别的参数了，就直接传参吧。